### PR TITLE
Updated makefile to explicitly use /bin/bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL = /bin/bash
+
 BASE_PACKAGES = corelib coreutils init login uberkernel uboot udev ush upt luamin
 PACKAGES = $(BASE_PACKAGES) libjson utar devutils Bedrock libbase64 libargparse libarchive 
 


### PR DESCRIPTION
Needed to support {} syntax for mkdir -p